### PR TITLE
Add newline at end of each hostname entry of hosts_dns_hostname

### DIFF
--- a/templates/hosts.j2
+++ b/templates/hosts.j2
@@ -41,6 +41,6 @@ ff02::3 ip6-allhosts
 
 {% if hosts_dns_hostname is defined %}
 {% for item in hosts_dns_hostname %}
-{{ item.address }} {{ item.hostname }}{% if item.aliases is defined %}{% for alias in item.aliases %} {{ alias }}{% endfor %}{% endif %}
+{{ item.address }} {{ item.hostname }}{% if item.aliases is defined %}{% for alias in item.aliases %} {{ alias }}{% endfor %}{% endif %} 
 {% endfor  %} 
 {% endif %}

--- a/templates/hosts.j2
+++ b/templates/hosts.j2
@@ -7,6 +7,22 @@
 127.0.0.1 localhost.localdomain localhost
 127.0.0.1 localhost4.localdomain4 localhost4
 {{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }} {{ inventory_hostname | lower }} {{ inventory_hostname_short | lower }}
+{% if ansible_default_ipv6.address is defined %}
+
+# The following lines are desirable for IPv6 capable hosts
+{% if hosts_hostname_loopback %}
+::1 {{ inventory_hostname | lower }} {{ inventory_hostname_short | lower }} 
+{% endif %}
+::1 localhost.localdomain localhost
+::1 localhost6.localdomain6 localhost6
+::1 ip6-localhost ip6-loopback
+{{ hostvars[inventory_hostname]['ansible_default_ipv6']['address'] }} {{ inventory_hostname | lower }} {{ inventory_hostname_short | lower }}
+fe00::0 ip6-localnet
+ff00::0 ip6-mcastprefix
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters
+ff02::3 ip6-allhosts
+{% endif %}
 {% if hosts_inventory_to_hosts %}
 {% for item in groups['all'] %}
 
@@ -21,19 +37,6 @@
 {{ hostvars[item]['ansible_host'] }}{% for item in hostvars[item]['hosts_aliases'] %} {{ item }}{% endfor %}
 {% endif %}
 {% if ansible_default_ipv6.address is defined %}
-# The following lines are desirable for IPv6 capable hosts
-{% if hosts_hostname_loopback %}
-::1 {{ inventory_hostname | lower }} {{ inventory_hostname_short | lower }} 
-{% endif %}
-::1 localhost.localdomain localhost
-::1 localhost6.localdomain6 localhost6
-::1 ip6-localhost ip6-loopback
-{{ hostvars[inventory_hostname]['ansible_default_ipv6'] }} {{ inventory_hostname | lower }} {{ inventory_hostname_short | lower }}
-fe00::0 ip6-localnet
-ff00::0 ip6-mcastprefix
-ff02::1 ip6-allnodes
-ff02::2 ip6-allrouters
-ff02::3 ip6-allhosts
 {{ hostvars[item]['ansible_default_ipv6']['address'] }}{% for item in hostvars[item]['hosts_aliases'] %} {{ item }}{% endfor %} 
 {% endif %}
 {% endfor  %}


### PR DESCRIPTION
I've added a space at the end of line 44 in hosts.j2 to create newlines after each entry.
And fix ipv6 entries creation