### PR TITLE
gather `ansible_default_ipv4` if undefined

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,16 @@
 ---
 # tasks file for arillso.hosts
 
+- name: Gather network facts, if necessary.
+  ansible.builtin.setup:
+    gather_subset:
+      - '!all'
+      - '!min'
+      - 'network'
+  when: ansible_default_ipv4 is undefined
+  tags:
+    - configuration
+
 - name: "Edits the hosts file in /etc"
   become: true
   ansible.builtin.template:


### PR DESCRIPTION
Currently the role [assumes](https://github.com/arillso/ansible.hosts/blob/main/templates/etc/hosts.j2#L40) the `ansible_default_ipv4` variable has been gathered prior to the roles execution. This results in the following failure:

```
TASK [arillso.hosts : Edits the hosts file in /etc] ****************************************************************************************************
fatal: [piTest]: FAILED! => {"changed": false, "msg": "AnsibleUndefinedVariable: {{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}: 'ansible.vars.hostvars.HostVarsVars object' has no attribute 'ansible_default_ipv4'"}
```

This PR adds a task to gather only the network facts from the host if `ansible_default_ipv4` is undefined.

@arillso thank you for your work.