### PR TITLE
fix: deprecated usage of ipaddr

### DIFF
--- a/templates/etc/hosts.j2
+++ b/templates/etc/hosts.j2
@@ -32,9 +32,9 @@ ff02::3 ip6-allhosts
 {% if hostvars[host]['ansible_interfaces'] is defined %}
 {% for interface in hostvars[host]['ansible_interfaces'] %}
 {% if interface | regex_search('^((?!' +  hosts_exludes_interfaces | join('|') + '*).)*$')  %}
-{% if hostvars[host]['ansible_' + interface]['ipv4']['address'] | ansible.netcommon.ipaddr('private') and hosts_all_private %}
+{% if hostvars[host]['ansible_' + interface]['ipv4']['address'] | ansible.utils.ipaddr('private') and hosts_all_private %}
 {{ hostvars[host]['ansible_' + interface]['ipv4']['address'] }} {{ hostvars[host]['ansible_hostname'] }} {{ host }}{{ " " if hostvars[host]['hosts_aliases'] is defined }}{% if hostvars[host]['hosts_aliases'] is defined %}{% for alias in hostvars[host]['hosts_aliases'] %}{{ alias }}{{ " " if not loop.last }}{% endfor %}{% endif %}{{ '\n' -}}
-{% elif hostvars[host]['ansible_' + interface]['ipv4']['address'] | ansible.netcommon.ipaddr('public') and hosts_all_public %}
+{% elif hostvars[host]['ansible_' + interface]['ipv4']['address'] | ansible.utils.ipaddr('public') and hosts_all_public %}
 {{ hostvars[host]['ansible_' + interface]['ipv4']['address'] }} {{ hostvars[host]['ansible_hostname'] }} {{ host }}{{ " " if hostvars[host]['hosts_aliases'] is defined }}{% if hostvars[host]['hosts_aliases'] is defined %}{% for alias in hostvars[host]['hosts_aliases'] %}{{ alias }}{{ " " if not loop.last }}{% endfor %}{% endif %}{{ '\n' -}}
 {% elif not hosts_all_private and not hosts_all_public %}
 {{ hostvars[host]['ansible_default_ipv4']['address'] }} {{ hostvars[host]['ansible_hostname'] }} {{ host }}{{ " " if hostvars[host]['hosts_aliases'] is defined }}{% if hostvars[host]['hosts_aliases'] is defined %}{% for alias in hostvars[host]['hosts_aliases'] %}{{ alias }}{{ " " if not loop.last }}{% endfor %}{% endif %}{{ '\n' -}}
@@ -48,9 +48,9 @@ ff02::3 ip6-allhosts
 {% if hostvars[host]['ansible_interfaces'] is defined %}
 {% for interface in hostvars[host]['ansible_interfaces'] %}
 {% if interface | regex_search('^((?!' +  hosts_exludes_interfaces | join('|') + '*).)*$')  %}
-{% if hostvars[host]['ansible_' + interface]['ipv6']['address'] | ansible.netcommon.ipaddr('private') and hosts_all_private %}
+{% if hostvars[host]['ansible_' + interface]['ipv6']['address'] | ansible.utils.ipaddr('private') and hosts_all_private %}
 {{ hostvars[host]['ansible_' + interface]['ipv6']['address'] }} {{ hostvars[host]['ansible_hostname'] }} {{ host }} {% set aliases=[] %}{% if hostvars[host]['hosts_aliases'] is defined %}{% for alias in hostvars[host]['hosts_aliases'] %}{% if alias != hostvars[host]['internel_ansible_host'] %}{{ aliases.append(alias) }}{% endif %}{% endfor %}{% endif %}
-{% elif hostvars[host]['ansible_' + interface]['ipv6']['address'] | ansible.netcommon.ipaddr('public') and hosts_all_public %}
+{% elif hostvars[host]['ansible_' + interface]['ipv6']['address'] | ansible.utils.ipaddr('public') and hosts_all_public %}
 {{ hostvars[host]['ansible_' + interface]['ipv6']['address'] }} {{ hostvars[host]['ansible_hostname'] }} {{ host }} {% set aliases=[] %}{% if hostvars[host]['hosts_aliases'] is defined %}{% for alias in hostvars[host]['hosts_aliases'] %}{% if alias != hostvars[host]['internel_ansible_host'] %}{{ aliases.append(alias) }}{% endif %}{% endfor %}{% endif %}
 {% elif not hosts_all_private and not hosts_all_public %}
 {{ hostvars[host]['ansible_default_ipv6']['address'] }} {{ hostvars[host]['ansible_hostname'] }} {{ host }} {% set aliases=[] %}{% if hostvars[host]['hosts_aliases'] is defined %}{% for alias in hostvars[host]['hosts_aliases'] %}{% if alias != hostvars[host]['internel_ansible_host'] %}{{ aliases.append(alias) }}{% endif %}{% endfor %}{% endif %}


### PR DESCRIPTION
`ipaddr` was moved to `ansible.utils` and as of 2024-01-01 should no longer be available elsewhere.